### PR TITLE
Update URL for Javadoc badge's image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # conversations-spring
 [![Build Status](https://api.travis-ci.org/maximilientyc/conversations-spring.svg)](https://travis-ci.org/maximilientyc/conversations-spring)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.maximilientyc/conversations-spring/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.maximilientyc/conversations-spring)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.github.maximilientyc/conversations-spring/badge.svg)](http://www.javadoc.io/doc/com.github.maximilientyc/conversations-spring)
+[![Javadoc](https://javadoc.io/badge/com.github.maximilientyc/conversations-spring.svg)](http://www.javadoc.io/doc/com.github.maximilientyc/conversations-spring)
 


### PR DESCRIPTION
OpenShit Online V2 is closed and this domain is not accessible anymore.
And javadoc.io introduce badges hosted directly on javadoc.io